### PR TITLE
Program version of ESAIM publication

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -12,7 +12,7 @@ jobs:
   # Do the G++-10 test!
   build_gnu10:
     name: Test build with g++-10
-    runs-on: ${{env.RUN_ON}}
+    runs-on: ubuntu-20.04
     env:
       CXX: g++-10
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   # Do the G++-10 test!
-  build_gnu10:
+  build_and_test:
     strategy:
       matrix:
         cxx_compiler: [g++-10 clang++-10]
@@ -18,7 +18,7 @@ jobs:
     name: Test build with g++-10
     runs-on: ubuntu-20.04
     env:
-      CXX: g++-10
+      CXX: ${{ matrix.cxx_compiler }}
 
     steps:
     - name: Checkout

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -11,7 +11,7 @@ jobs:
   build_and_test:
     strategy:
       matrix:
-        os:  [ ubuntu-20.04 ]
+        os:  [ macos-11, ubuntu-20.04 ]
         cxx: [ clang++-10, clang++-11, clang++-12, g++-10 ]
 
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -9,16 +9,16 @@ env:
   RUN_ON: ubuntu-20.04
 
 jobs:
-  # Do the G++-10 test!
   build_and_test:
     strategy:
       matrix:
-        cxx_compiler: [g++-10 clang++-10]
+        os: [ubuntu-20.04]
+        cxx: [g++-10, clang++-10]
 
     name: Test build with g++-10
-    runs-on: ubuntu-20.04
+    runs-on: ${{ matrix.os }}
     env:
-      CXX: ${{ matrix.cxx_compiler }}
+      CXX: ${{ matrix.cxx }}
 
     steps:
     - name: Checkout

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -11,6 +11,10 @@ env:
 jobs:
   # Do the G++-10 test!
   build_gnu10:
+    strategy:
+      matrix:
+        cxx_compiler: [g++-10 clang++-10]
+
     name: Test build with g++-10
     runs-on: ubuntu-20.04
     env:

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -11,7 +11,7 @@ jobs:
   build_and_test:
     strategy:
       matrix:
-        os:  [ macos-11, ubuntu-20.04 ]
+        os:  [ ubuntu-20.04 ]
         cxx: [ clang++-10, clang++-11, clang++-12, g++-10 ]
 
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -6,12 +6,13 @@ on: [push]
 
 env:
   PYTHON: python3-dev python3-numpy python3-scipy cython3
+  RUN_ON: ubuntu-20.04
 
 jobs:
   # Do the G++-10 test!
   build_gnu10:
     name: Test build with g++-10
-    runs-on: ubuntu-20.04
+    runs-on: ${{env.RUN_ON}}
     env:
       CXX: g++-10
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -6,7 +6,6 @@ on: [push]
 
 env:
   PYTHON: python3-dev python3-numpy python3-scipy cython3
-  RUN_ON: ubuntu-20.04
 
 jobs:
   build_and_test:
@@ -15,49 +14,13 @@ jobs:
         os: [ubuntu-20.04]
         cxx: [g++-10, clang++-10]
 
-    name: Test build with g++-10
-    runs-on: ${{ matrix.os }}
     env:
       CXX: ${{ matrix.cxx }}
+      OS: ${{ matrix.os }}
 
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-      with:
-       submodules: recursive
-    - name: Install Python
-      run: sudo apt-get update; sudo apt-get install -y ${{env.PYTHON}}
-    - name: Conduct CMake Test
-      uses: HyperHDG/actions@cmake
-      with:
-        cxx_compiler: ${{env.CXX}}
+    name: Test build with g++-10
+    runs-on: ${{ env.OS }}
 
-  # Do the Clang++-10 test!
-  build_clang10:
-    name: Test build with clang++-10
-    runs-on: ubuntu-20.04
-    env:
-      CXX: clang++-10
-    
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-      with:
-       submodules: recursive
-    - name: Install Python
-      run: sudo apt-get update; sudo apt-get install -y ${{env.PYTHON}}
-    - name: Conduct CMake Test
-      uses: HyperHDG/actions@cmake
-      with:
-        cxx_compiler: ${{env.CXX}}
-
-  # Do the Clang++-11 test!
-  build_clang11:
-    name: Test build with clang++-11
-    runs-on: ubuntu-20.04
-    env:
-      CXX: clang++-11
-    
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -6,14 +6,13 @@ on: [push]
 
 env:
   PYTHON: python3-dev python3-numpy python3-scipy cython3
-  RUN_ON: ubuntu-20.04
 
 jobs:
   
   # Do the Clang++-10 test!
   build_clang10:
     name: Test build with clang++-10
-    runs-on: ${{env.RUN_ON}}
+    runs-on: ubuntu-20.04
     env:
       CXX: clang++-10
     
@@ -32,7 +31,7 @@ jobs:
   # Do the Clang++-11 test!
   build_clang11:
     name: Test build with clang++-11
-    runs-on: ${{env.RUN_ON}}
+    runs-on: ubuntu-20.04
     env:
       CXX: clang++-11
     
@@ -51,7 +50,7 @@ jobs:
   # Do the Clang++-12 test!
   build_clang11:
     name: Test build with clang++-12
-    runs-on: ${{env.RUN_ON}}
+    runs-on: ubuntu-20.04
     env:
       CXX: clang++-12
     
@@ -70,7 +69,7 @@ jobs:
   # Do the G++-10 test!
   build_gnu10:
     name: Test build with g++-10
-    runs-on: ${{env.RUN_ON}}
+    runs-on: ubuntu-20.04
     env:
       CXX: g++-10
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -17,7 +17,7 @@ jobs:
     env:
       CXX: ${{ matrix.cxx }}
 
-    name: Test build with ${{ matrix.cxx }}
+    name: Test build with ${{ matrix.cxx }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -14,7 +14,6 @@ jobs:
         os:  [ ubuntu-20.04 ]
         cxx: [ clang++-10, clang++-11, clang++-12, g++-10 ]
 
-
     name: Test code with ${{ matrix.cxx }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -6,31 +6,14 @@ on: [push]
 
 env:
   PYTHON: python3-dev python3-numpy python3-scipy cython3
+  RUN_ON: ubuntu-20.04
 
 jobs:
-  # Do the G++-10 test!
-  build_gnu10:
-    name: Test build with g++-10
-    runs-on: ubuntu-20.04
-    env:
-      CXX: g++-10
-
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-      with:
-       submodules: recursive
-    - name: Install Python
-      run: sudo apt-get update; sudo apt-get install -y ${{env.PYTHON}}
-    - name: Conduct CMake Test
-      uses: HyperHDG/actions@cmake
-      with:
-        cxx_compiler: ${{env.CXX}}
-
+  
   # Do the Clang++-10 test!
   build_clang10:
     name: Test build with clang++-10
-    runs-on: ubuntu-20.04
+    runs-on: ${{env.RUN_ON}}
     env:
       CXX: clang++-10
     
@@ -49,10 +32,48 @@ jobs:
   # Do the Clang++-11 test!
   build_clang11:
     name: Test build with clang++-11
-    runs-on: ubuntu-20.04
+    runs-on: ${{env.RUN_ON}}
     env:
       CXX: clang++-11
     
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+       submodules: recursive
+    - name: Install Python
+      run: sudo apt-get update; sudo apt-get install -y ${{env.PYTHON}}
+    - name: Conduct CMake Test
+      uses: HyperHDG/actions@cmake
+      with:
+        cxx_compiler: ${{env.CXX}}
+
+  # Do the Clang++-12 test!
+  build_clang11:
+    name: Test build with clang++-12
+    runs-on: ${{env.RUN_ON}}
+    env:
+      CXX: clang++-12
+    
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+       submodules: recursive
+    - name: Install Python
+      run: sudo apt-get update; sudo apt-get install -y ${{env.PYTHON}}
+    - name: Conduct CMake Test
+      uses: HyperHDG/actions@cmake
+      with:
+        cxx_compiler: ${{env.CXX}}
+
+  # Do the G++-10 test!
+  build_gnu10:
+    name: Test build with g++-10
+    runs-on: ${{env.RUN_ON}}
+    env:
+      CXX: g++-10
+
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -8,7 +8,25 @@ env:
   PYTHON: python3-dev python3-numpy python3-scipy cython3
 
 jobs:
-  
+  # Do the G++-10 test!
+  build_gnu10:
+    name: Test build with g++-10
+    runs-on: ubuntu-20.04
+    env:
+      CXX: g++-10
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+       submodules: recursive
+    - name: Install Python
+      run: sudo apt-get update; sudo apt-get install -y ${{env.PYTHON}}
+    - name: Conduct CMake Test
+      uses: HyperHDG/actions@cmake
+      with:
+        cxx_compiler: ${{env.CXX}}
+
   # Do the Clang++-10 test!
   build_clang10:
     name: Test build with clang++-10
@@ -35,44 +53,6 @@ jobs:
     env:
       CXX: clang++-11
     
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-      with:
-       submodules: recursive
-    - name: Install Python
-      run: sudo apt-get update; sudo apt-get install -y ${{env.PYTHON}}
-    - name: Conduct CMake Test
-      uses: HyperHDG/actions@cmake
-      with:
-        cxx_compiler: ${{env.CXX}}
-
-  # Do the Clang++-12 test!
-  build_clang11:
-    name: Test build with clang++-12
-    runs-on: ubuntu-20.04
-    env:
-      CXX: clang++-12
-    
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-      with:
-       submodules: recursive
-    - name: Install Python
-      run: sudo apt-get update; sudo apt-get install -y ${{env.PYTHON}}
-    - name: Conduct CMake Test
-      uses: HyperHDG/actions@cmake
-      with:
-        cxx_compiler: ${{env.CXX}}
-
-  # Do the G++-10 test!
-  build_gnu10:
-    name: Test build with g++-10
-    runs-on: ubuntu-20.04
-    env:
-      CXX: g++-10
-
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -16,10 +16,9 @@ jobs:
 
     env:
       CXX: ${{ matrix.cxx }}
-      OS: ${{ matrix.os }}
 
-    name: Test build with g++-10
-    runs-on: ${{env.OS}}
+    name: Test build with ${{ matrix.cxx }}
+    runs-on: ${{ matrix.os }}
 
     steps:
     - name: Checkout

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -19,7 +19,7 @@ jobs:
       OS: ${{ matrix.os }}
 
     name: Test build with g++-10
-    runs-on: ${{ env.OS }}
+    runs-on: ${{env.OS}}
 
     steps:
     - name: Checkout

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -11,13 +11,11 @@ jobs:
   build_and_test:
     strategy:
       matrix:
-        os: [ubuntu-20.04]
-        cxx: [g++-10, clang++-10]
+        os:  [ ubuntu-20.04 ]
+        cxx: [ clang++-10, clang++-11, clang++-12, g++-10 ]
 
-    env:
-      CXX: ${{ matrix.cxx }}
 
-    name: Test build with ${{ matrix.cxx }} on ${{ matrix.os }}
+    name: Test code with ${{ matrix.cxx }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -26,8 +24,8 @@ jobs:
       with:
        submodules: recursive
     - name: Install Python
-      run: sudo apt-get update; sudo apt-get install -y ${{env.PYTHON}}
-    - name: Conduct CMake Test
+      run: sudo apt-get update; sudo apt-get install -y ${{ env.PYTHON }}
+    - name: Conduct cmake test
       uses: HyperHDG/actions@cmake
       with:
-        cxx_compiler: ${{env.CXX}}
+        cxx_compiler: ${{ matrix.cxx }}

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ and easy to handle teaching scripts/programs.
 
 For more details on HyperHDG, you may visit the [website of HyperHDG](
 https://hyperhdg.github.io/HyperHDG), the [Doxygen page](
-https://hyperhdg.github.io/auto_pages/doxygen), or its [Wiki](../../wiki).
+https://hyperhdg.github.io/auto_pages/doxygen), or its [Wiki](../../wiki). In particular, if you
+want to know how to setup HyperHDG, we recommend to visit the [Wiki's setup page](../../wiki/Setup).
 
 
 ## Status of continuous integration

--- a/reproducibles_python/diffusion_convergence_hypergraph_elliptic_high_order.py
+++ b/reproducibles_python/diffusion_convergence_hypergraph_elliptic_high_order.py
@@ -1,0 +1,87 @@
+from __future__ import print_function
+
+import numpy as np
+import scipy.sparse.linalg as sp_lin_alg
+from scipy.sparse.linalg import LinearOperator
+
+from datetime import datetime
+
+import os, sys
+
+
+# --------------------------------------------------------------------------------------------------
+# Function bilaplacian_test.
+# --------------------------------------------------------------------------------------------------
+def diffusion_test(poly_degree, dimension, iteration, refinement, debug_mode=False):
+  start_time = datetime.now()
+  print("Starting time is", start_time)
+  os.system("mkdir -p output")
+  
+  try:
+    import HyperHDG
+  except (ImportError, ModuleNotFoundError) as error:
+    sys.path.append(os.path.dirname(os.path.abspath(__file__)) + "/../import")
+    import HyperHDG
+  
+  const                 = HyperHDG.config()
+  const.global_loop     = "Elliptic"
+  const.topology        = "Cubic<" + str(dimension) + ",3>"
+  const.geometry        = "UnitCube<" + str(dimension) + ",3,double>"
+  const.node_descriptor = "Cubic<" + str(dimension) + ",3>"
+  const.local_solver    = "Diffusion<" + str(dimension) + "," + str(poly_degree) + "," \
+    + str(6) + ",HG<" + str(dimension) + ">::TestParametersQuadElliptHO,double>"
+  const.cython_replacements = ["vector[unsigned int]", "vector[unsigned int]"]
+  const.include_files   = ["reproducibles_python/parameters/diffusion.hxx"]
+  const.debug_mode      = debug_mode
+
+  PyDP = HyperHDG.include(const)
+  HDG_wrapper = PyDP( [2 ** iteration] * 3 )
+  
+  HDG_wrapper.refine( 2 ** refinement )
+
+  vectorRHS = np.multiply(HDG_wrapper.residual_flux(HDG_wrapper.zero_vector()), -1.)
+
+  system_size = HDG_wrapper.size_of_system()
+  A = LinearOperator( (system_size,system_size), matvec= HDG_wrapper.trace_to_flux )
+
+  [vectorSolution, num_iter] = sp_lin_alg.cg(A, vectorRHS, tol=1e-13)
+  if num_iter != 0:
+    raise RuntimeError("Linear solver did not converge!")
+
+  error = HDG_wrapper.errors(vectorSolution)[0]
+  print("Refinement: ", refinement, " Error: ", error)
+  f = open("output/diffusion_convergence_hypergraph_elliptic_high_order.txt", "a")
+  f.write("Polynomial degree = " + str(poly_degree) + ". Dimension = " + str(dimension) \
+          + ". Refinement = " + str(refinement) + ". Error = " + str(error) + ".\n")
+  f.close()
+  
+  HDG_wrapper.plot_option( "fileName", "diff_hg_conv_ho-" + str(dimension) + "-" + str(refinement) )
+  HDG_wrapper.plot_option( "printFileNumber", "false" )
+  HDG_wrapper.plot_option( "scale", "0.95" )
+  HDG_wrapper.plot_solution(vectorSolution)
+  
+  end_time = datetime.now()
+  print("Program ended at", end_time, "after", end_time-start_time)
+  
+
+# --------------------------------------------------------------------------------------------------
+# Function main.
+# --------------------------------------------------------------------------------------------------
+def main(debug_mode):
+  iteration = 1
+  for poly_degree in range(1,4):
+    print("\n Polynomial degree is set to be ", poly_degree, "\n\n")
+    for dimension in range(2,3):
+      print("Dimension is ", dimension, "\n")
+      for refinement in range(5):
+        try:
+          diffusion_test(poly_degree, dimension, iteration, refinement, debug_mode)
+        except RuntimeError as error:
+          print("ERROR: ", error)
+
+
+# --------------------------------------------------------------------------------------------------
+# Define main function.
+# -------------------------------------------------------------------------------------------------- 
+if __name__ == "__main__":
+  main(len(sys.argv) > 1 and sys.argv[1] == "True")

--- a/reproducibles_python/diffusion_convergence_hypergraph_elliptic_high_order_postprocess.py
+++ b/reproducibles_python/diffusion_convergence_hypergraph_elliptic_high_order_postprocess.py
@@ -28,7 +28,7 @@ def diffusion_test(poly_degree, dimension, iteration, refinement, debug_mode=Fal
   const.topology        = "Cubic<" + str(dimension) + ",3>"
   const.geometry        = "UnitCube<" + str(dimension) + ",3,double>"
   const.node_descriptor = "Cubic<" + str(dimension) + ",3>"
-  const.local_solver    = "Diffusion<" + str(dimension) + "," + str(poly_degree) + "," \
+  const.local_solver    = "DiffusionPostprocess<" + str(dimension) + "," + str(poly_degree) + "," \
     + str(6) + ",HG<" + str(dimension) + ">::TestParametersQuadElliptHO,double>"
   const.cython_replacements = ["vector[unsigned int]", "vector[unsigned int]"]
   const.include_files   = ["reproducibles_python/parameters/diffusion.hxx"]
@@ -50,12 +50,12 @@ def diffusion_test(poly_degree, dimension, iteration, refinement, debug_mode=Fal
 
   error = HDG_wrapper.errors(vectorSolution)[0]
   print("Refinement: ", refinement, " Error: ", error)
-  f = open("output/diffusion_convergence_hypergraph_elliptic_high_order.txt", "a")
+  f = open("output/diffusion_convergence_hypergraph_elliptic_high_order_pp.txt", "a")
   f.write("Polynomial degree = " + str(poly_degree) + ". Dimension = " + str(dimension) \
           + ". Refinement = " + str(refinement) + ". Error = " + str(error) + ".\n")
   f.close()
   
-  HDG_wrapper.plot_option( "fileName", "diff_hg_conv_ho-" + str(dimension) + "-" + str(refinement) )
+  HDG_wrapper.plot_option( "fileName", "diff_hg_conv_ho_pp-"+str(dimension)+"-"+str(refinement) )
   HDG_wrapper.plot_option( "printFileNumber", "false" )
   HDG_wrapper.plot_option( "scale", "0.95" )
   HDG_wrapper.plot_solution(vectorSolution)

--- a/reproducibles_python/parameters/diffusion.hxx
+++ b/reproducibles_python/parameters/diffusion.hxx
@@ -101,6 +101,55 @@ struct HG
       return 0.;
     }
   };
+  template <unsigned int space_dimT, typename param_float_t = double>
+  struct TestParametersQuadElliptHO
+  {
+    static constexpr std::array<unsigned int, 26U> dirichlet_nodes{
+      1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13,
+      14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26};
+    static constexpr std::array<unsigned int, 0U> neumann_nodes{};
+    static param_float_t diffusion_coeff(const Point<space_dimT, param_float_t>&,
+                                         const param_float_t = 0.)
+    {
+      return 1.;
+    }
+    static param_float_t inverse_diffusion_coeff(const Point<space_dimT, param_float_t>&,
+                                                 const param_float_t = 0.)
+    {
+      return 4. * M_PI * M_PI;
+    }
+
+    static param_float_t analytic_result(const Point<space_dimT, param_float_t>& point,
+                                         const param_float_t = 0.)
+    {
+      param_float_t result = 0;
+      for (unsigned int dim = 0; dim < space_dimT; ++dim)
+        result += sin(2. * M_PI * point[dim]);
+      return result;
+    }
+
+    static param_float_t right_hand_side(const Point<space_dimT, param_float_t>& point,
+                                         const param_float_t = 0.)
+    {
+      return analytic_result(point);
+    }
+
+    static param_float_t dirichlet_value(const Point<space_dimT, param_float_t>& point,
+                                         const param_float_t = 0.)
+    {
+      return analytic_result(point);
+    }
+    static param_float_t initial(const Point<space_dimT, param_float_t>& point,
+                                 const param_float_t = 0.)
+    {
+      return analytic_result(point);
+    }
+    static param_float_t neumann_value(const Point<space_dimT, param_float_t>&,
+                                       const param_float_t = 0.)
+    {
+      return 0.;
+    }
+  };
 };
 
 template <unsigned int space_dimT, typename param_float_t = double>

--- a/reproducibles_python/parameters/diffusion.hxx
+++ b/reproducibles_python/parameters/diffusion.hxx
@@ -111,7 +111,7 @@ struct HG
     static param_float_t diffusion_coeff(const Point<space_dimT, param_float_t>&,
                                          const param_float_t = 0.)
     {
-      return 1.;
+      return 0.25 / M_PI / M_PI;
     }
     static param_float_t inverse_diffusion_coeff(const Point<space_dimT, param_float_t>&,
                                                  const param_float_t = 0.)

--- a/shell_scripts/push_test.sh
+++ b/shell_scripts/push_test.sh
@@ -4,7 +4,7 @@
 COL='\e[0;36m'  # text format 3 -> 'text color', 6 -> 'cyan'
 NOR='\e[0m'     # text format 'standard'
 
-TEST_COMPILER=("clang++-10" "clang++-11" "g++-10")
+TEST_COMPILER=("clang++-10" "clang++-11" "clang++-12" "g++-10")
 
 
 test_compiler()
@@ -34,7 +34,7 @@ for comp in ${TEST_COMPILER[*]}; do test_compiler ${comp} |& tee -a output/push_
 rm -rf build domains/*.pts.geo \
   doxygen/html doxygen/latex doxygen/doxy_log.txt \
   .ipynb_checkpoints */.ipynb_checkpoints */*/.ipynb_checkpoints */*.nbconvert.* jupyter/*.py \
-  __pycache__ */__pycache__ */*/__pycache__ |& tee output/push_test.txt
+  __pycache__ */__pycache__ */*/__pycache__
 
 ./shell_scripts/setup.sh -Cd |& tee -a output/push_test.txt
 


### PR DESCRIPTION
- Add an analytical testcase for higher order approximations (with and without postprocessing) on hypergraphs
- Improve the `push_test.sh` script
- Highlight the Wiki's setup page in the beginning of the README
- Simplify `cmake.yml` workflow, such that new compilers or operating system versions can be added in a single line

Unfortunately, GitHub appears to support Ubuntu 18.04 and 20.04, but currently no other versions.