### PR TITLE
Include lost flags for more performant cython compilation.

### DIFF
--- a/cmake_cython.cfg.in
+++ b/cmake_cython.cfg.in
@@ -1,7 +1,7 @@
 [compiler]
 command  = ${CMAKE_CXX_COMPILER}
 includes = -I${Python3_INCLUDE_DIRS} -I${PROJECT_SOURCE_DIR} -I${PROJECT_SOURCE_DIR}/include -I${PROJECT_SOURCE_DIR}/submodules/tensor_product_chain_complex.git/include -I${PROJECT_SOURCE_DIR}/submodules/tensor_product_polynomials.git/include 
-flags    = ${CMAKE_CXX_FLAGS} -fPIC
+flags    = ${CMAKE_CXX_FLAGS} -shared -pthread -fPIC -fwrapv -O3 -Wall -fno-strict-aliasing
 standard = 20
 
 [linker]


### PR DESCRIPTION
One might also consider writing `-O3` into the `CMAKE_CXX_FLAGS`.

This is the recommended compile command of the cython documentation (which replaces `-O3` by `-O2`---which is 30% slower on my laptop and thus we use `-O3`).