### PR TITLE
Changes for Apple clang 17

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         osys: [ ubuntu-24.04 ]
-        comp: [ {cxx: clang++-18}, {cxx: g++-13} ]
+        comp: [ {cxx: clang++-18}, {cxx: clang++-19}, {cxx: clang++-20}, {cxx: g++-13},  {cxx: g++-14},  {cxx: g++-13}]
 
     name: Test code with ${{ matrix.comp.cxx }} on ${{ matrix.osys }}
     runs-on: ${{ matrix.osys }}

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         osys: [ ubuntu-24.04 ]
-        comp: [ {cxx: clang++-18}, {cxx: clang++-19}, {cxx: clang++-20}, {cxx: g++-13},  {cxx: g++-14},  {cxx: g++-13}]
+        comp: [ {cxx: clang++-18}, {cxx: clang++-19}, {cxx: g++-13},  {cxx: g++-14}]
 
     name: Test code with ${{ matrix.comp.cxx }} on ${{ matrix.osys }}
     runs-on: ${{ matrix.osys }}

--- a/.github/workflows/make_doxygen.yml
+++ b/.github/workflows/make_doxygen.yml
@@ -5,7 +5,7 @@ name: Doxygen
 on: push
 
 env:
-  CXX: g++-10
+  CXX: g++-14
 
 jobs:
   make_and_deploy_doxygen:

--- a/include/HyperHDG/local_solver/diffusion_ldgh.hxx
+++ b/include/HyperHDG/local_solver/diffusion_ldgh.hxx
@@ -1092,7 +1092,7 @@ Diffusion<hyEdge_dimT, poly_deg, quad_deg, parametersT, lSol_float_t>::assemble_
     for (unsigned int j = 0; j < n_shape_fct_; ++j)
       right_hand_side[hyEdge_dimT * n_shape_fct_ + i] +=
         coeffs[hyEdge_dimT * n_shape_fct_ + j] *
-        integrator::template integrate_vol_phiphi(i, j, hyper_edge.geometry);
+        integrator::integrate_vol_phiphi(i, j, hyper_edge.geometry);
 
   return right_hand_side;
 }  // end of Diffusion::assemble_rhs_from_coeffs

--- a/include/HyperHDG/node_descriptor/file.hxx
+++ b/include/HyperHDG/node_descriptor/file.hxx
@@ -152,7 +152,7 @@ class File
                   hyEdge_index_t,
                   hyNode_index_t,
                   pt_index_t>& other)
-  : domain_info_(other.domain_info),
+  : domain_info_(other.domain_info()),
     n_subintervals_(1),
     tpcc_ref_elem_(
       Wrapper::create_tpcc<hyEdge_dimT, hyEdge_dimT, TPCC::boundaries::both, hyEdge_index_t>(
@@ -180,6 +180,22 @@ class File
    * \brief   Return the refinement level (equal to number of subintervals).
    ************************************************************************************************/
   unsigned int get_refinement() const { return n_subintervals_; }
+  /*!***********************************************************************************************
+   * \brief   Return the whole domain info related to a hypergraph.
+   *
+   * \retval  domain_info     Const reference to domain info.
+   ************************************************************************************************/
+  const DomainInfo<hyEdge_dimT,
+                   space_dimT,
+                   vectorT,
+                   pointT,
+                   hyEdge_index_t,
+                   hyNode_index_t,
+                   pt_index_t>&
+  domain_info() const
+  {
+    return domain_info_;
+  }
   /*!***********************************************************************************************
    * \brief   Set the refinement level (equal to number of subintervals).
    ************************************************************************************************/


### PR DESCRIPTION
With the new Apple clang compiler version 17, two new errors have been introduced. This pull request is supposed two fix those two errors. Changes are:

- a getter-function for the private domain_info_-variable in the node_descriptor file class has been introduced to avoid an access which caused an error. An analogous construction can be found in the topology file class.
- in the integrator, an untemplated version of the function integrate_vol_phiphi is used. Consequently, the template keyword has been removed.